### PR TITLE
pin mypy to at least 0.980

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,7 @@ jobs:
 
   - script: python -m mypy confection
     displayName: 'Run mypy'
+    condition: ne(variables['python.version'], '3.10')
 
   - task: DeleteFiles@1
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,6 @@ jobs:
 
   - script: python -m mypy confection
     displayName: 'Run mypy'
-    condition: ne(variables['python.version'], '3.10')
 
   - task: DeleteFiles@1
     inputs:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ srsly>=2.4.0,<3.0.0
 # Development requirements
 pathy>=0.3.5
 pytest>=5.2.0,!=7.1.0
-mypy>=0.901,<0.970; platform_machine!='aarch64'
+mypy>=0.980,<0.990; platform_machine!='aarch64'
 types-dataclasses>=0.1.3; python_version < "3.7"
 numpy>=1.15.0


### PR DESCRIPTION
mypy `0.981` has been released today - this should hopefully fix the tests for Python 3.10.