### PR TITLE
Fix required maximum version of typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic>=1.7.4,!=1.8,!=1.8.1,<1.11.0
-typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
 srsly>=2.4.0,<3.0.0
 # Development requirements
 pathy>=0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic>=1.7.4,!=1.8,!=1.8.1,<1.11.0
-typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 srsly>=2.4.0,<3.0.0
 # Development requirements
 pathy>=0.3.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     pydantic>=1.7.4,!=1.8,!=1.8.1,<1.11.0
-    typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
     srsly>=2.4.0,<3.0.0
 
 [sdist]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     pydantic>=1.7.4,!=1.8,!=1.8.1,<1.11.0
-    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
     srsly>=2.4.0,<3.0.0
 
 [sdist]


### PR DESCRIPTION
This PR fixes the required maximum version of typing-extensions.

Currently it is bounded to <4.2.0: `typing_extensions>=3.7.4.1,<4.2.0; python_version < "3.8"`

This PR sets the upper bound to all compatible versions, until the next major release <5.0.0.

See:
- https://github.com/explosion/spaCy/issues/12034

See issue in pydantic:
- https://github.com/pydantic/pydantic/issues/4885

See fixing PR in pydantic (`typing-extensions>=4.2.0`), which will be incompatible with your requirement `typing_extensions>=3.7.4,<4.2.0; python_version < "3.8"`:
- https://github.com/pydantic/pydantic/pull/4886