### PR TITLE
Add check for single quoted values

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -44,7 +44,7 @@ class CustomInterpolation(ExtendedInterpolation):
             json_value = srsly.json_loads(value)
             if isinstance(json_value, str) and json_value not in JSON_EXCEPTIONS:
                 value = json_value
-        except Exception:
+        except ValueError:
             if value and value[0] == value[-1] == "'":
                 warnings.warn(
                     f"The value [{value}] seems to be single-quoted, but values "

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -16,6 +16,7 @@ import inspect
 import io
 import copy
 import re
+import warnings
 
 from .util import Decorator
 

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -44,7 +44,11 @@ class CustomInterpolation(ExtendedInterpolation):
             if isinstance(json_value, str) and json_value not in JSON_EXCEPTIONS:
                 value = json_value
         except Exception:
-            pass
+            if value and value[0] == "'" and value[-1] == "'":
+                warnings.warn(
+                    f"The value [{value}] seems to be single-quoted, but values "
+                    "use JSON formatting, which requires double quotes."
+                )
         return super().before_read(parser, section, option, value)
 
     def before_get(self, parser, section, option, value, defaults):

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -45,7 +45,7 @@ class CustomInterpolation(ExtendedInterpolation):
             if isinstance(json_value, str) and json_value not in JSON_EXCEPTIONS:
                 value = json_value
         except Exception:
-            if value and value[0] == "'" and value[-1] == "'":
+            if value and value[0] == value[-1] == "'":
                 warnings.warn(
                     f"The value [{value}] seems to be single-quoted, but values "
                     "use JSON formatting, which requires double quotes."

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -50,6 +50,8 @@ class CustomInterpolation(ExtendedInterpolation):
                     f"The value [{value}] seems to be single-quoted, but values "
                     "use JSON formatting, which requires double quotes."
                 )
+        except Exception:
+            pass
         return super().before_read(parser, section, option, value)
 
     def before_get(self, parser, section, option, value, defaults):

--- a/confection/tests/test_config.py
+++ b/confection/tests/test_config.py
@@ -1379,3 +1379,20 @@ def test_config_overrides(greeting, value, expected):
     assert "${vars.a}" in str_cfg
     cfg = Config().from_str(str_cfg, overrides=overrides)
     assert expected in str(cfg)
+
+
+def test_warn_single_quotes():
+    str_cfg = f"""
+    [project]
+    commands = 'do stuff'
+    """
+
+    with pytest.warns(UserWarning, match="single-quoted"):
+        cfg = Config().from_str(str_cfg)
+
+    # should not warn if single quotes are in the middle
+    str_cfg = f"""
+    [project]
+    commands = some'thing
+    """
+    cfg = Config().from_str(str_cfg)


### PR DESCRIPTION
Values in confection are JSON values. One thing that can confuse people is that single quoting such values is not valid, and the quotes will be interpreted as being part of the string, as raised in https://github.com/explosion/spaCy/issues/9454. 

This PR checks for values that seem to be single quoted and warns about them.

Also, I hadn't realized it before this PR, but apparently empty values are valid, like this:

```
[x]
y =
z = 2
```