### PR TITLE
fixes #29: removed recursive parsing for lists

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -273,8 +273,6 @@ class Config(dict):
         # NOTE: This currently can't handle uninterpolated values like [${x.y}]!
         if isinstance(result, str) and VARIABLE_RE.search(value):
             result = value
-        if isinstance(result, list):
-            return [self._interpret_value(v) for v in result]
         return result
 
     def _get_section_ref(self, value: Any, *, parent: List[str] = []) -> Any:


### PR DESCRIPTION
I removed 2 lines from the \_\_init\_\_.py file.

The only case I can think of that requires those lines is a json inside a string somewhere, but I'm not sure why this could be wanted behaviour. Something like this:
```
[test]
a = ["[1,2,3]"]
```

This makes it very hard to keep away json-like strings from conversion. For my use case I had to replace this code
```
[test]
a = ["001", "002"]
```
with this
```
[test]
a = ["\"001\"", "\"002\""]
```
which is not a very clean solution.