### PR TITLE
Remove recursive parsing for lists

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -273,8 +273,6 @@ class Config(dict):
         # NOTE: This currently can't handle uninterpolated values like [${x.y}]!
         if isinstance(result, str) and VARIABLE_RE.search(value):
             result = value
-        if isinstance(result, list):
-            return [self._interpret_value(v) for v in result]
         return result
 
     def _get_section_ref(self, value: Any, *, parent: List[str] = []) -> Any:

--- a/confection/tests/test_config.py
+++ b/confection/tests/test_config.py
@@ -1398,7 +1398,6 @@ def test_warn_single_quotes():
     cfg = Config().from_str(str_cfg)
 
 
-@pytest.mark.xfail
 def test_parse_strings_interpretable_as_ints():
     """Test whether strings interpretable as integers are parsed correctly (i. e. as strings)."""
     cfg = Config().from_str(f"""[a]\nfoo = [${{b.bar}}, "00${{b.bar}}", "y"]\n\n[b]\nbar = 3""")


### PR DESCRIPTION
Follow-up for #30 with tests for int/string parsing from #32.