### PR TITLE
Fix spacy init issue

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -19,6 +19,12 @@ import warnings
 
 from .util import Decorator, SimpleFrozenDict, SimpleFrozenList, PYDANTIC_V2
 
+if TYPE_CHECKING and PYDANTIC_V2:
+    from pydantic.v1.fields import ModelField
+else:
+    from pydantic.fields import ModelField
+
+
 # Field used for positional arguments, e.g. [section.*.xyz]. The alias is
 # required for the schema (shouldn't clash with user-defined arg names)
 ARGS_FIELD = "*"
@@ -661,16 +667,28 @@ def alias_generator(name: str) -> str:
     return name
 
 
+def _copy_model_field_v1(field: ModelField, type_: Any) -> ModelField:
+    return ModelField(
+        name=field.name,
+        type_=type_,
+        class_validators=field.class_validators,
+        model_config=field.model_config,
+        default=field.default,
+        default_factory=field.default_factory,
+        required=field.required,
+    )
+
+
 def copy_model_field(field: FieldInfo, type_: Any) -> FieldInfo:
     """Copy a model field and assign a new type, e.g. to accept an Any type
     even though the original value is typed differently.
     """
-    field_info = copy.deepcopy(field)
     if PYDANTIC_V2:
+        field_info = copy.deepcopy(field)
         field_info.annotation = type_  # type: ignore
+        return field_info
     else:
-        field_info.type_ = type_  # type: ignore
-    return field_info
+        return _copy_model_field_v1(field, type_)  # type: ignore
 
 
 def get_model_config_extra(model: Type[BaseModel]) -> str:

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -22,7 +22,7 @@ from .util import Decorator, SimpleFrozenDict, SimpleFrozenList, PYDANTIC_V2
 if PYDANTIC_V2:
     from pydantic.v1.fields import ModelField  # type: ignore
 else:
-    from pydantic.fields import ModelField
+    from pydantic.fields import ModelField  # type: ignore
 
 
 # Field used for positional arguments, e.g. [section.*.xyz]. The alias is

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -19,8 +19,8 @@ import warnings
 
 from .util import Decorator, SimpleFrozenDict, SimpleFrozenList, PYDANTIC_V2
 
-if TYPE_CHECKING and PYDANTIC_V2:
-    from pydantic.v1.fields import ModelField
+if PYDANTIC_V2:
+    from pydantic.v1.fields import ModelField  # type: ignore
 else:
     from pydantic.fields import ModelField
 


### PR DESCRIPTION
Promise validation was broken because the new implementation of `copy_model_field` didn't actually change the type. So when setting a promise field, we still had the original schema type (in the case of `spacy init config` this caused an issue with the `tokenizer` promise.

The schema in spacy has this as a callable but we want to validate as Any cause it's a promise. 

This code isn't super clean but fixes the main issue