### PR TITLE
Preserve $$ escaping in Config.to_str

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -150,7 +150,7 @@ class CustomInterpolation(ExtendedInterpolation):
                 else:
                     accum.append(v)
             else:
-                err = "'$' must be followed by '$' or '{', " "found: %r" % (rest,)
+                err = "'$' must be followed by '$' or '{', found: %r" % (rest,)
                 raise InterpolationSyntaxError(option, section, err)
 
     def _get_section_name(self, name: str) -> str:
@@ -520,7 +520,10 @@ def try_dump_json(value: Any, data: Union[Dict[str, dict], Config, str] = "") ->
         # Work around values that are strings but numbers
         value = f'"{value}"'
     try:
-        return srsly.json_dumps(value)
+        value = srsly.json_dumps(value)
+        value = re.sub(r"\$([^{])", "$$\1", value)
+        value = re.sub(r"\$$", "$$", value)
+        return value
     except Exception as e:
         err_msg = (
             f"Couldn't serialize config value of type {type(value)}: {e}. Make "

--- a/confection/tests/test_config.py
+++ b/confection/tests/test_config.py
@@ -290,6 +290,29 @@ bar = 1
     )
 
 
+def test_config_to_str_escapes():
+    section_str = """
+        [section]
+        node1 = "^a$$"
+        node2 = "$$b$$c"
+        """
+    section_dict = {"section": {"node1": "^a$", "node2": "$b$c"}}
+
+    # parse from escaped string
+    cfg = Config().from_str(section_str)
+    assert cfg == section_dict
+
+    # parse from non-escaped dict
+    cfg = Config(section_dict)
+    assert cfg == section_dict
+
+    # roundtrip through str
+    cfg_str = cfg.to_str()
+    assert "^a$$" in cfg_str
+    new_cfg = Config().from_str(cfg_str)
+    assert cfg == section_dict
+
+
 def test_config_roundtrip_bytes():
     cfg = Config().from_str(OPTIMIZER_CFG)
     cfg_bytes = cfg.to_bytes()


### PR DESCRIPTION
Output `$$` as the escaped value of literal `$` in `Config.to_str` to preserve the literal `$` value (as opposed to the variable `${...}`).