### PR TITLE
Fixed issue where config with  `*` could not be filled

### DIFF
--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -692,6 +692,7 @@ def alias_generator(name: str) -> str:
     return name
 
 
+
 def copy_model_field(field: ModelField, type_: Any) -> ModelField:
     """Copy a model field and assign a new type, e.g. to accept an Any type
     even though the original value is typed differently.
@@ -936,7 +937,12 @@ class registry:
             # manually because .construct doesn't parse anything
             if schema.Config.extra in (Extra.forbid, Extra.ignore):
                 fields = schema.__fields__.keys()
-                exclude = [k for k in result.__fields_set__ if k not in fields]
+                # If we have a reserved field, we need to use its alias
+                field_set = [
+                    k if k != ARGS_FIELD else ARGS_FIELD_ALIAS for k in result.__fields_set__
+                ]
+                # field_set = result.__fields_set__
+                exclude = [k for k in field_set if k not in fields]
         exclude_validation = set([ARGS_FIELD_ALIAS, *RESERVED_FIELDS.keys()])
         validation.update(result.dict(exclude=exclude_validation))
         filled, final = cls._update_from_parsed(validation, filled, final)

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -692,7 +692,6 @@ def alias_generator(name: str) -> str:
     return name
 
 
-
 def copy_model_field(field: ModelField, type_: Any) -> ModelField:
     """Copy a model field and assign a new type, e.g. to accept an Any type
     even though the original value is typed differently.
@@ -949,7 +948,8 @@ class registry:
                 fields = schema.__fields__.keys()
                 # If we have a reserved field, we need to use its alias
                 field_set = [
-                    k if k != ARGS_FIELD else ARGS_FIELD_ALIAS for k in result.__fields_set__
+                    k if k != ARGS_FIELD else ARGS_FIELD_ALIAS
+                    for k in result.__fields_set__
                 ]
                 exclude = [k for k in field_set if k not in fields]
         exclude_validation = set([ARGS_FIELD_ALIAS, *RESERVED_FIELDS.keys()])

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -951,7 +951,6 @@ class registry:
                 field_set = [
                     k if k != ARGS_FIELD else ARGS_FIELD_ALIAS for k in result.__fields_set__
                 ]
-                # field_set = result.__fields_set__
                 exclude = [k for k in field_set if k not in fields]
         exclude_validation = set([ARGS_FIELD_ALIAS, *RESERVED_FIELDS.keys()])
         validation.update(result.dict(exclude=exclude_validation))

--- a/confection/__init__.py
+++ b/confection/__init__.py
@@ -705,6 +705,7 @@ def copy_model_field(field: ModelField, type_: Any) -> ModelField:
         default=field.default,
         default_factory=field.default_factory,
         required=field.required,
+        alias=field.alias,
     )
 
 
@@ -913,6 +914,15 @@ class registry:
                     # created via config blocks), only use its values
                     validation[v_key] = list(validation[v_key].values())
                     final[key] = list(final[key].values())
+
+                    if ARGS_FIELD_ALIAS in schema.__fields__ and not resolve:
+                        # If we're not resolving the config, make sure that the field
+                        # expecting the promise is typed Any so it doesn't fail
+                        # validation if it doesn't receive the function return value
+                        field = schema.__fields__[ARGS_FIELD_ALIAS]
+                        schema.__fields__[ARGS_FIELD_ALIAS] = copy_model_field(
+                            field, Any
+                        )
             else:
                 filled[key] = value
                 # Prevent pydantic from consuming generator if part of a union

--- a/confection/tests/test_config.py
+++ b/confection/tests/test_config.py
@@ -424,6 +424,31 @@ def test_make_config_positional_args():
     assert my_registry.resolve(cfg)["config"] == "^_^"
 
 
+def test_fill_config_positional_args_w_promise():
+    @my_registry.cats("catsie.v568")
+    def catsie_568(*args: str, foo: str = "bar"):
+        assert args[0] == "^(*.*)^"
+        assert foo == "baz"
+        return args[0]
+
+    @my_registry.cats("cat_promise.v568")
+    def cat_promise() -> str:
+        return "^(*.*)^"
+
+    cfg = {
+        "test_fn": {"@cats": "catsie.v568", "*": {"test_arg": {"@registry": "factory"}}}
+    }
+    cfg = {
+        "config": {
+            "@cats": "catsie.v568",
+            "*": {"promise": {"@cats": "cat_promise.v568"}},
+        }
+    }
+    filled = my_registry.fill(cfg, validate=True)
+    assert filled["config"]["foo"] == "bar"
+    assert filled["config"]["*"] == {"promise": {"@cats": "cat_promise.v568"}}
+
+
 def test_make_config_positional_args_complex():
     @my_registry.cats("catsie.v890")
     def catsie_890(*args: Optional[Union[StrictBool, PositiveInt]]):

--- a/confection/tests/test_config.py
+++ b/confection/tests/test_config.py
@@ -436,9 +436,6 @@ def test_fill_config_positional_args_w_promise():
         return "^(*.*)^"
 
     cfg = {
-        "test_fn": {"@cats": "catsie.v568", "*": {"test_arg": {"@registry": "factory"}}}
-    }
-    cfg = {
         "config": {
             "@cats": "catsie.v568",
             "*": {"promise": {"@cats": "cat_promise.v568"}},


### PR DESCRIPTION
- fix field exclusion logic (only relevant when validate=False)
- Added missing alias when creating copy of field
- copy field (in case validate = True) when using a promise within a positional argument
- Added test

fixes #47 