### PR TITLE
Bump typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
-typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
+typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
 srsly>=2.4.0,<3.0.0
 # Development requirements
 catalogue>=2.0.3,<2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 0.1.5a0
+version = 0.1.5
 description = The sweetest config system for Python
 url = https://github.com/explosion/confection
 author = Explosion

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = true
 python_requires = >=3.6
 install_requires =
     pydantic>=1.7.4,!=1.8,!=1.8.1,<3.0.0
-    typing_extensions>=3.7.4.1,<4.5.0; python_version < "3.8"
+    typing_extensions>=3.7.4.1,<5.0.0; python_version < "3.8"
     srsly>=2.4.0,<3.0.0
 
 [sdist]


### PR DESCRIPTION
Allow up to `typing_extensions<5.0.0` to avoid install conflicts.

Bumping `confection` to `0.1.5`.